### PR TITLE
allow batch processing of up to 10 messages

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -9,7 +9,13 @@ const schema = joi.object({
   to: joi
     .string()
     .uri()
-    .required()
+    .required(),
+  batchSize: joi
+    .number()
+    .min(1)
+    .max(10)
+    .optional()
+    .default(1)
 });
 
 const validateParams = params => {
@@ -22,8 +28,8 @@ const validateParams = params => {
 
 if (require.main === module) {
   (async function() {
-    const [from, to] = process.argv.slice(2);
-    const params = { from, to };
+    const [from, to, batchSize] = process.argv.slice(2);
+    const params = { from, to, batchSize };
     if (validateParams(params)) await redrive(params);
   })();
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,7 +2,12 @@ const { Consumer } = require('sqs-consumer');
 const Producer = require('sqs-producer');
 const util = require('util');
 
-const redrive = ({ from: sourceQueueUrl, to: destQueueUrl, options = {} }) => {
+const redrive = ({
+  from: sourceQueueUrl,
+  to: destQueueUrl,
+  batchSize,
+  options = {}
+}) => {
   const { sqs } = options;
   return new Promise((resolve, reject) => {
     const handleError = err => {
@@ -18,9 +23,19 @@ const redrive = ({ from: sourceQueueUrl, to: destQueueUrl, options = {} }) => {
     const isFIFO = /\.fifo$/.test(destQueueUrl);
     const target = Producer.create({
       sqs,
-      queueUrl: destQueueUrl
+      queueUrl: destQueueUrl,
+      batchSize
     });
     const send = util.promisify(target.send.bind(target));
+
+    const sourceProducer = Producer.create({
+      sqs,
+      queueUrl: sourceQueueUrl,
+      batchSize
+    });
+    const queueSize = util.promisify(
+      sourceProducer.queueSize.bind(sourceProducer)
+    );
 
     const reportCompletion = () => {
       source.stop();
@@ -28,7 +43,7 @@ const redrive = ({ from: sourceQueueUrl, to: destQueueUrl, options = {} }) => {
       resolve();
     };
 
-    const handleMessage = async message => {
+    const handleMessage = message => {
       let payload = {
         id: message.MessageId,
         body: message.Body
@@ -42,14 +57,27 @@ const redrive = ({ from: sourceQueueUrl, to: destQueueUrl, options = {} }) => {
           deduplicationId: `${message.MessageId}_${Date.now()}`
         };
       }
-      await send(payload);
       count++;
+
+      return payload;
+    };
+
+    const handleMessageBatch = async messages => {
+      await send(messages.map(handleMessage));
+
+      console.log(`processed ${count / batchSize} batches`);
+
+      if (count % 100 === 0) {
+        const itemsInQueue = await queueSize();
+        console.log(`\n\n\n${itemsInQueue} messages left in queue\n\n\n`);
+      }
     };
 
     const source = Consumer.create({
       queueUrl: sourceQueueUrl,
       sqs,
-      handleMessage
+      batchSize,
+      handleMessageBatch
     });
 
     source.on('error', handleError);


### PR DESCRIPTION
We have to replay 300k messages and doing it one by one was just too slow.
This PR adds the `batchSize` option to process up to 10 messages as a batch. 10 is the upper limit of SQS

This  will speed up the replay by up to 10 times.

