### PR TITLE
Add support for MessageAttributes

### DIFF
--- a/lib/__tests__/replayAwsDlq.test.js
+++ b/lib/__tests__/replayAwsDlq.test.js
@@ -6,7 +6,16 @@ const mockMessages = [
     MessageId: '226052d0-5f52-4df8-91d2-53d58afdfc2c',
     Body:
       '{"id":"5d31a25ae887bb000828e6f3","entityName":"photo","source":"gqes"}',
-    ReceiptHandle: 'receipt-handle-1'
+    ReceiptHandle: 'receipt-handle-1',
+    MessageAttributes: {
+      SomeImportantAttr: {
+        StringValue: 'foobar',
+        BinaryValue: null,
+        BinaryListValue: [],
+        StringListValue: [],
+        DataType: 'String'
+      }
+    }
   },
   {
     MessageId: '28cce3b3-003c-4920-9e11-e7904ee3f2c7',
@@ -107,7 +116,13 @@ describe('redrive messages', () => {
               '{"id":"5d31a25ae887bb000828e6f3","entityName":"photo","source":"gqes"}',
             Id: '226052d0-5f52-4df8-91d2-53d58afdfc2c',
             MessageGroupId: 're-drive',
-            MessageDeduplicationId: expect.any(String)
+            MessageDeduplicationId: expect.any(String),
+            MessageAttributes: {
+              SomeImportantAttr: {
+                DataType: 'String',
+                StringValue: 'foobar'
+              }
+            }
           }
         ]
       },
@@ -123,7 +138,8 @@ describe('redrive messages', () => {
               '{"id":"5cdc0ae662fe4009f083f690","entityName":"photo","source":"gqin"}',
             Id: '28cce3b3-003c-4920-9e11-e7904ee3f2c7',
             MessageGroupId: 're-drive',
-            MessageDeduplicationId: expect.any(String)
+            MessageDeduplicationId: expect.any(String),
+            MessageAttributes: {}
           }
         ]
       },

--- a/lib/index.js
+++ b/lib/index.js
@@ -29,9 +29,20 @@ const redrive = ({ from: sourceQueueUrl, to: destQueueUrl, options = {} }) => {
     };
 
     const handleMessage = async message => {
+      const messageAttributes = Object.entries(
+        message.MessageAttributes || {}
+      ).reduce((sendMessageAttrs, [key, value]) => {
+        sendMessageAttrs[key] = {
+          StringValue: value.StringValue,
+          DataType: value.DataType
+        };
+        return sendMessageAttrs;
+      }, {});
+
       let payload = {
         id: message.MessageId,
-        body: message.Body
+        body: message.Body,
+        messageAttributes
       };
 
       // For FIFO queue we need to make sure this message is unique and is in correct order
@@ -49,7 +60,8 @@ const redrive = ({ from: sourceQueueUrl, to: destQueueUrl, options = {} }) => {
     const source = Consumer.create({
       queueUrl: sourceQueueUrl,
       sqs,
-      handleMessage
+      handleMessage,
+      messageAttributeNames: ['All']
     });
 
     source.on('error', handleError);


### PR DESCRIPTION
I tried to use this recently on a queue that was making use of message attributes and the attributes were stripped off when requeuing.

Small PR to move all String attributes across.